### PR TITLE
Add support for upstreamURLs in ConfigMap and Deployment

### DIFF
--- a/deployments/kubernetes/chart/gitwebhookproxy/templates/configmap.yaml
+++ b/deployments/kubernetes/chart/gitwebhookproxy/templates/configmap.yaml
@@ -16,6 +16,7 @@ data:
     provider: {{ . }}
     {{- end }}
     upstreamURL: {{ .Values.gitWebhookProxy.config.upstreamURL }}
+    upstreamURLs: {{ .Values.gitWebhookProxy.config.upstreamURLs | default "" }}
     {{- with .Values.gitWebhookProxy.config.allowedPaths }}
     allowedPaths: {{ . }}
     {{- end }}

--- a/deployments/kubernetes/chart/gitwebhookproxy/templates/deployment.yaml
+++ b/deployments/kubernetes/chart/gitwebhookproxy/templates/deployment.yaml
@@ -53,6 +53,15 @@ spec:
             {{- else }}
               name: {{ template "gitwebhookproxy.name" . }}
             {{- end }}
+        - name: GWP_UPSTREAMURLs
+          valueFrom:
+            configMapKeyRef:
+              key: upstreamURLs
+            {{- if .Values.gitWebhookProxy.useCustomName }}
+              name: {{ .Values.gitWebhookProxy.customName }}
+            {{- else }}
+              name: {{ template "gitwebhookproxy.name" . }}
+            {{- end }}            
         - name: GWP_ALLOWEDPATHS
           valueFrom:
             configMapKeyRef:

--- a/deployments/kubernetes/chart/gitwebhookproxy/values.yaml
+++ b/deployments/kubernetes/chart/gitwebhookproxy/values.yaml
@@ -20,6 +20,7 @@ gitWebhookProxy:
   config:
     provider: github
     upstreamURL: "https://jenkins.tools.stackator.com"
+    upstreamURLs: ""
     allowedPaths: "/github-webhook,/project"
     secret: ""
     ignoredUsers: "stakater-user"


### PR DESCRIPTION
Introduce support for multiple upstream URLs in the configuration, allowing for enhanced flexibility in deployment settings. Update the ConfigMap and Deployment templates accordingly.